### PR TITLE
Add stddef.h to avoid to missing size_t

### DIFF
--- a/atasmart.h
+++ b/atasmart.h
@@ -24,6 +24,7 @@
 ***/
 
 #include <inttypes.h>
+#include <stddef.h>
 
 /* Please note that all enums defined here may be extended at any time
  * without this being considered an ABI change. So take care when


### PR DESCRIPTION
solve the issue: https://github.com/openEuler-Storage/libatasmart/issues/4
Missing header dependency 